### PR TITLE
Allow publish interval of 0 to publish as metrics received

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ lo               loopback  unmanaged    --
 
 ### PUBLISH_INTERVAL_SEC
 
-Interval between publishing metrics, in seconds. Defaults to `300` (5 minutes).
+Interval between publishing metrics, in seconds. Allows accumulating byte totals for a period longer than the interval between incoming metrics messages.  Defaults to `0`, which publishes totals as messages received. So, if metrics messages are received every 10 seconds and PUBLISH_INTERVAL_SEC is 30, accumulates byte totals over 3 incoming messages before publishing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       MQTT_ADDRESS: '127.0.0.1'
       METRICS_REQUEST: 'networkStats/(*), networkStats/iface, networkStats/rx_bytes, networkStats/tx_bytes'
-      READING_INTERVAL_MS: '10000'
+      READING_INTERVAL_MS: '300000'
     depends_on:
         - "mqtt"
   mqtt:

--- a/index.js
+++ b/index.js
@@ -42,7 +42,9 @@ async function connectLocal() {
 }
 
 /**
- * Runs the logger. On each publish interval, logs elapsed RX and TX byte totals.
+ * Runs the logger and listens for metrics messages. Logs elapsed RX and TX byte
+ * totals on each publish interval. If publish interval is 0, logs as metrics
+ * messages are received.
  */
 async function start() {
     let startRx = 0, startTx = 0
@@ -51,8 +53,8 @@ async function start() {
         await connectLocal()
 
         let pubInterval = process.env.PUBLISH_INTERVAL_SEC
-        if (!pubInterval) {
-            pubInterval = 300
+        if (typeof pubInterval === 'undefined') {
+            pubInterval = 0
         }
         console.log(`Publish interval: ${pubInterval} sec`)
         pubInterval *= 1000
@@ -71,11 +73,17 @@ async function start() {
                     console.log(`Received initial loggable message for interface ${iface}; starting publish interval`)
                     console.log("elapsedRx,elapsedTx")
 
-                    setInterval(function() {
-                        console.log(`${lastRx - startRx},${lastTx - startTx}`)
-                        startRx = lastRx
-                        startTx = lastTx
-                    }, pubInterval)
+                    if (pubInterval != 0) {
+                        setInterval(function() {
+                            console.log(`${lastRx - startRx},${lastTx - startTx}`)
+                            startRx = lastRx
+                            startTx = lastTx
+                        }, pubInterval)
+                    }
+                } else if (pubInterval == 0) {
+                    console.log(`${lastRx - startRx},${lastTx - startTx}`)
+                    startRx = lastRx
+                    startTx = lastTx
                 }
             })
         }

--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ async function start() {
                 if (startRx == 0) {
                     startRx = lastRx
                     startTx = lastTx
-                    const iface = stats.iface ? stats.iface : "(not provided)"
-                    console.log(`Received initial loggable message for interface ${iface}; starting publish interval`)
+                    const ifaceText = stats.iface ? stats.iface : "<unknown>"
+                    console.log(`Received initial loggable message for interface ${ifaceText}; starting publish interval`)
                     console.log("elapsedRx,elapsedTx")
 
                     if (pubInterval != 0) {


### PR DESCRIPTION
Allow environment variable PUBLISH_INTERVAL_SEC to be 0, which means metrics are published as received. The value of 0 is the new default. This change is feasible now that the System Metrics block includes a delay before publishing the first metric reading.

Together these changes mean the user can set a large value for System Metrics reading interval, which simplifies the overall setup for metrics logging.